### PR TITLE
Upgrade gradle, support lib, move common versions to root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ android:
     - platform-tools
     - tools
     - android-25
-    - build-tools-25.0.0
+    - build-tools-25.0.2
 
 licenses:
   - 'android-sdk-license-.+'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.3'
+    classpath 'com.android.tools.build:gradle:2.3.0'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     classpath 'com.vanniktech:gradle-android-junit-jacoco-plugin:0.5.0'
   }
@@ -18,6 +18,15 @@ allprojects {
     maven { url "https://jitpack.io" }
     mavenCentral()
   }
+}
+
+ext {
+  compileSdkVersion = 25
+  buildToolsVersion = '25.0.2'
+  minSdkVersion = 15
+  targetSdkVersion = compileSdkVersion
+
+  supportLibVersion = '25.3.1'
 }
 
 subprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Dec 15 20:21:14 PST 2016
+#Wed Mar 29 09:26:11 BST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -12,12 +12,12 @@ install {
 }
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion '25.0.0'
+  compileSdkVersion rootProject.ext.compileSdkVersion
+  buildToolsVersion rootProject.ext.buildToolsVersion
 
   defaultConfig {
-    minSdkVersion 15
-    targetSdkVersion 25
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
     versionCode 1
     versionName "1.0"
     consumerProguardFiles 'proguard-rules.pro'
@@ -39,7 +39,7 @@ dependencies {
   compile 'com.github.material-motion:indefinite-observable-android:develop-SNAPSHOT'
   compile 'com.github.material-motion:gestures-android:develop-SNAPSHOT'
   compile 'com.github.material-motion:physics-android:develop-SNAPSHOT'
-  compile 'com.android.support:support-core-utils:25.1.0'
+  compile "com.android.support:support-core-utils:$supportLibVersion"
 
   testCompile 'com.google.truth:truth:0.28'
   testCompile 'junit:junit:4.12'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.0'
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.google.android.reactive.motion.sample"
-        minSdkVersion 15
-        targetSdkVersion 25
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
     }
@@ -31,7 +31,7 @@ android {
 dependencies {
     // If you are developing any dependencies locally, also list them in local.dependencies.
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile "com.android.support:appcompat-v7:$supportLibVersion"
+    compile "com.android.support:recyclerview-v7:$supportLibVersion"
     compile 'pl.droidsonroids.gif:android-gif-drawable:1.2.5'
 }


### PR DESCRIPTION
Defining common version numbers in the root project makes it easier to
keep everything in sync when we upgrade things.