### PR TITLE
Implement MotionRuntime.get() API

### DIFF
--- a/library/src/main/java/com/google/android/material/motion/MotionRuntime.java
+++ b/library/src/main/java/com/google/android/material/motion/MotionRuntime.java
@@ -15,7 +15,9 @@
  */
 package com.google.android.material.motion;
 
+import android.support.v4.util.SimpleArrayMap;
 import android.util.Property;
+import android.view.View;
 
 import com.google.android.indefinite.observable.IndefiniteObservable.Subscription;
 
@@ -28,6 +30,7 @@ import java.util.List;
 public final class MotionRuntime {
 
   private final List<Subscription> subscriptions = new ArrayList<>();
+  private final SimpleArrayMap<View, ReactiveView> cachedReactiveViews = new SimpleArrayMap<>();
 
   /**
    * Subscribes to the stream, writes its output to the given property, and observes its state.
@@ -59,5 +62,18 @@ public final class MotionRuntime {
   public final <O, T> void addInteraction(
     Interaction<O, T> interaction, O target, ConstraintApplicator<T> constraints) {
     interaction.apply(this, target, constraints);
+  }
+
+  /**
+   * Returns a reactive version of the given object and caches the returned result for future access.
+   */
+  public ReactiveView get(View view) {
+    ReactiveView reactiveView = cachedReactiveViews.get(view);
+    if (reactiveView == null) {
+      reactiveView = new ReactiveView(view);
+      cachedReactiveViews.put(view, reactiveView);
+    }
+
+    return reactiveView;
   }
 }

--- a/library/src/main/java/com/google/android/material/motion/ReactiveView.java
+++ b/library/src/main/java/com/google/android/material/motion/ReactiveView.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016-present The Material Motion Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.material.motion;
+
+import android.annotation.TargetApi;
+import android.graphics.PointF;
+import android.os.Build;
+import android.view.View;
+
+import com.google.android.material.motion.properties.ViewProperties;
+
+/**
+ * A ReactiveView is a view that wraps around an Android View class.
+ * It contains Reactive Properties that you can subscribe to.
+ */
+public class ReactiveView {
+  private final View view;
+
+  public ReactiveView(View view) {
+    this.view = view;
+  }
+
+  public ReactiveProperty<PointF> translation() {
+    return ReactiveProperty.of(view, ViewProperties.TRANSLATION);
+  }
+
+  public ReactiveProperty<PointF> center() {
+    return ReactiveProperty.of(view, ViewProperties.CENTER);
+  }
+
+  public ReactiveProperty<PointF> scale() {
+    return ReactiveProperty.of(view, ViewProperties.SCALE);
+  }
+
+  public ReactiveProperty<PointF> pivot() {
+    return ReactiveProperty.of(view, ViewProperties.PIVOT);
+  }
+
+  public ReactiveProperty<Integer> backgroundColor() {
+    return ReactiveProperty.of(view, ViewProperties.BACKGROUND_COLOR);
+  }
+
+  public ReactiveProperty<Float> translationX() {
+    return ReactiveProperty.of(view, View.TRANSLATION_X);
+  }
+
+  public ReactiveProperty<Float> translationY() {
+    return ReactiveProperty.of(view, View.TRANSLATION_Y);
+  }
+
+  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+  public ReactiveProperty<Float> translationZ() {
+    return ReactiveProperty.of(view, View.TRANSLATION_Z);
+  }
+
+  public ReactiveProperty<Float> rotationX() {
+    return ReactiveProperty.of(view, View.ROTATION_X);
+  }
+
+  public ReactiveProperty<Float> rotationY() {
+    return ReactiveProperty.of(view, View.ROTATION_Y);
+  }
+
+  public ReactiveProperty<Float> scaleX() {
+    return ReactiveProperty.of(view, View.SCALE_X);
+  }
+
+  public ReactiveProperty<Float> scaleY() {
+    return ReactiveProperty.of(view, View.SCALE_Y);
+  }
+
+  public ReactiveProperty<Float> x() {
+    return ReactiveProperty.of(view, View.X);
+  }
+
+  public ReactiveProperty<Float> y() {
+    return ReactiveProperty.of(view, View.Y);
+  }
+
+  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+  public ReactiveProperty<Float> z() {
+    return ReactiveProperty.of(view, View.Z);
+  }
+
+  public ReactiveProperty<Float> alpha() {
+    return ReactiveProperty.of(view, View.ALPHA);
+  }
+}

--- a/library/src/test/java/com/google/android/material/motion/MotionRuntimeTests.java
+++ b/library/src/test/java/com/google/android/material/motion/MotionRuntimeTests.java
@@ -16,9 +16,12 @@
 package com.google.android.material.motion;
 
 import android.app.Activity;
+import android.graphics.Color;
+import android.graphics.PointF;
 import android.view.View;
 
 import com.google.android.material.motion.testing.SimulatedMotionSource;
+import com.google.android.material.motion.testing.TrackingMotionObserver;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -40,6 +43,150 @@ public class MotionRuntimeTests {
   @Before
   public void setUp() {
     runtime = new MotionRuntime();
+  }
+
+  @Test
+  public void writeAndReadCenterProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).center().write(new PointF(15, 40));
+    assertThat(runtime.get(target).center().read()).isEqualTo(new PointF(15, 40));
+
+    runtime.get(target).center().write(new PointF(1, 2));
+    assertThat(runtime.get(target).center().read()).isEqualTo(new PointF(1, 2));
+  }
+
+  @Test
+  public void readWriteSubscribeCenterProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).center().write(new PointF(1,2));
+
+    TrackingMotionObserver<PointF> tracker = new TrackingMotionObserver<>();
+    runtime.get(target).center().subscribe(tracker);
+
+    runtime.get(target).center().write(new PointF(15,40));
+    runtime.get(target).center().write(new PointF(7,13));
+
+    assertThat(tracker.values).containsAllOf(new PointF(1,2), new PointF(15,40), new PointF(7,13));
+  }
+
+  @Test
+  public void readWritePositionProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).translation().write(new PointF(10,21));
+
+    assertThat(runtime.get(target).translation().read()).isEqualTo(new PointF(10, 21));
+  }
+
+  @Test
+  public void readWriteScaleProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).scale().write(new PointF(80,2));
+
+    assertThat(runtime.get(target).scale().read()).isEqualTo(new PointF(80, 2));
+  }
+
+  @Test
+  public void readWritePivotProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).pivot().write(new PointF(74,52));
+
+    assertThat(runtime.get(target).pivot().read()).isEqualTo(new PointF(74, 52));
+  }
+
+  @Test
+  public void readWriteBackgroundColorProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).backgroundColor().write(new Integer(Color.RED));
+
+    assertThat(runtime.get(target).backgroundColor().read()).isEqualTo(new Integer(Color.RED));
+  }
+
+  @Test
+  public void readWriteTranslationXProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).translationX().write(5.0f);
+
+    assertThat(runtime.get(target).translationX().read()).isWithin(0.5f).of(5.0f);
+  }
+
+  @Test
+  public void readWriteTranslationYProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).translationY().write(9.0f);
+
+    assertThat(runtime.get(target).translationY().read()).isWithin(0.5f).of(9.0f);
+  }
+
+  @Test
+  public void readWriteTranslationZProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).translationZ().write(7.0f);
+
+    assertThat(runtime.get(target).translationZ().read()).isWithin(0.5f).of(7.0f);
+  }
+
+  @Test
+  public void readWriteRotationXProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).rotationX().write(17.0f);
+
+    assertThat(runtime.get(target).rotationX().read()).isWithin(0.5f).of(17.0f);
+  }
+
+  @Test
+  public void readWriteRotationYProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).rotationY().write(33.0f);
+
+    assertThat(runtime.get(target).rotationY().read()).isWithin(0.5f).of(33.0f);
+  }
+
+  @Test
+  public void readWriteScaleXProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).scaleX().write(11.0f);
+
+    assertThat(runtime.get(target).scaleX().read()).isWithin(0.5f).of(11.0f);
+  }
+
+  @Test
+  public void readWriteScaleYProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).scaleY().write(55.0f);
+
+    assertThat(runtime.get(target).scaleY().read()).isWithin(0.5f).of(55.0f);
+  }
+
+  @Test
+  public void readWriteXProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).x().write(62.0f);
+
+    assertThat(runtime.get(target).x().read()).isWithin(0.5f).of(62.0f);
+  }
+
+  @Test
+  public void readWriteYProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).y().write(23.0f);
+
+    assertThat(runtime.get(target).y().read()).isWithin(0.5f).of(23.0f);
+  }
+
+  @Test
+  public void readWriteZProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).z().write(54.0f);
+
+    assertThat(runtime.get(target).z().read()).isWithin(0.5f).of(54.0f);
+  }
+
+  @Test
+  public void readAlphaProperty() {
+    View target = new View(Robolectric.setupActivity(Activity.class));
+    runtime.get(target).alpha().write(0.5f);
+
+    assertThat(runtime.get(target).alpha().read()).isWithin(0.5f).of(0.5f);
   }
 
   @Test

--- a/sample/src/main/java/com/google/android/material/motion/sample/TossableTapActivity.java
+++ b/sample/src/main/java/com/google/android/material/motion/sample/TossableTapActivity.java
@@ -50,7 +50,7 @@ public class TossableTapActivity extends AppCompatActivity {
   }
 
   private void runDemo() {
-    ReactiveProperty<PointF> anchor = ReactiveProperty.of(ViewProperties.CENTER.get(target));
+    ReactiveProperty<PointF> anchor = runtime.get(target).center();
 
     Tossable tossable = new Tossable(ViewProperties.CENTER, anchor);
     runtime.addInteraction(tossable, target);
@@ -58,6 +58,6 @@ public class TossableTapActivity extends AppCompatActivity {
     runtime.addInteraction(new SetPositionOnTap(container), tossable.anchor);
 
     runtime.write(
-      tossable.anchor.getStream(), ReactiveProperty.of(destination, ViewProperties.CENTER));
+      tossable.anchor.getStream(), runtime.get(destination).center());
   }
 }


### PR DESCRIPTION
Summary:
Added ReactiveView class as a wrapper around ReactiveProperty.of() function. Added get() to MotionRuntime class that returns a ReactiveView class.

Fixes https://github.com/material-motion/material-motion-android/issues/72

Tags: #material_motion