### PR TITLE
Use WeakHashMap for MotionRuntime's target-based caches

### DIFF
--- a/library/src/main/java/com/google/android/material/motion/MotionRuntime.java
+++ b/library/src/main/java/com/google/android/material/motion/MotionRuntime.java
@@ -23,6 +23,7 @@ import com.google.android.indefinite.observable.IndefiniteObservable.Subscriptio
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.WeakHashMap;
 
 /**
  * A MotionRuntime writes the output of streams to properties and observes their overall state.
@@ -30,9 +31,9 @@ import java.util.List;
 public final class MotionRuntime {
 
   private final List<Subscription> subscriptions = new ArrayList<>();
-  private final SimpleArrayMap<View, ReactiveView> cachedReactiveViews = new SimpleArrayMap<>();
-  private final SimpleArrayMap<Object, List<Interaction<?, ?>>> cachedInteractions =
-    new SimpleArrayMap<>();
+  private final WeakHashMap<View, ReactiveView> cachedReactiveViews = new WeakHashMap<>();
+  private final WeakHashMap<Object, List<Interaction<?, ?>>> cachedInteractions =
+    new WeakHashMap<>();
 
   /**
    * Subscribes to the stream, writes its output to the given property, and observes its state.


### PR DESCRIPTION
Summary:
Use WeakHashMap instead of SimpleArrayMap

Fixes https://github.com/material-motion/material-motion-android/issues/76

Reviewers: O2 Material Motion, O6 Material Android platform reviewers, #material_motion, markwei

Reviewed By: O2 Material Motion, O6 Material Android platform reviewers, #material_motion, markwei

Tags: #material_motion

Differential Revision: http://codereview.cc/D3102